### PR TITLE
resize path footer based on terminal width

### DIFF
--- a/fff
+++ b/fff
@@ -24,8 +24,10 @@ f_print() {
         [[ $co == "${f[i]}" ]] && { fo+='\e[1m\e[3'"${FFF_COL:-6}m"'\e[7m'; }
         printf '\e[K%b%s\e[m\n' "$fo" "$path"; fo=
     }
+    term=$(tput cols); t="${PWD/\/\//\/} (${l:-1}/$((c-1)))";
+    ((term < ${#t})) && t=...${t:${#t}-term+4}
     printf '\e[3%sm\e[%s;H\e[K\n\e[K%s\e[m\e[H' "${FFF_COL2:-7}" "$((LINES-2))" \
-           "${PWD/\/\//\/} (${l:-1}/$((c-1))) ${co:+${pr[*]}: ${co##*/} [p]}"
+           "$t ${co:+${pr[*]}: ${co##*/} [p]}"
 }
 
 hist() {


### PR DESCRIPTION
On smaller terminal windows or with very small paths, the right-hand portion of the path is lost. This change truncates the starting portion of the path, so

    /home/jumanjicostco/github/fff (0/4)
would become 

    ...anjicostoco/github/fff (0/4)
