### PR TITLE
general: Use XDG dirs by default.

### DIFF
--- a/fff
+++ b/fff
@@ -14,9 +14,6 @@ get_os() {
 
         haiku)
             opener="open"
-
-            # ':' is a way of avoiding 'var=var' when using '${:-}/${:+}/${:=}'.
-            : "${FFF_TRASH:=$(finddir B_USER_CACHE_DIRECTORY)/fff/trash/}"
         ;;
     esac
 }
@@ -541,7 +538,8 @@ key() {
 
         # Quit and store current directory in a file for CD on exit.
         q)
-            printf '%s\n' "$PWD" > "${FFF_CD_FILE:-$HOME/.fff_d}"
+            : "${FFF_CD_FILE:=${XDG_CACHE_HOME:=${HOME}/.cache}/fff/.fff_d}"
+            printf '%s\n' "$PWD" > "$FFF_CD_FILE"
             exit
         ;;
     esac
@@ -585,7 +583,7 @@ main() {
 
     # Create the trash directory if it doesn't exist.
     # Better to get this done early.
-    mkdir -p "${FFF_TRASH:=${HOME}/.cache/fff/trash}"
+    mkdir -p "${FFF_TRASH:=${XDG_CACHE_HOME:=${HOME}/.cache}/fff/trash}"
 
     # Trap the exit signal (we need to reset the terminal to a useable state.)
     # '\e[?1049l': Restore saved terminal screen.


### PR DESCRIPTION
Closes #50 

Uses `FFF_` variables first. If they're empty, uses `XDG_CACHE_HOME`. If that's empty we fallback to the default value `${HOME}/.cache`.

> $XDG_CACHE_HOME defines the base directory relative to which user specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.

> https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html