### PR TITLE
PageUp/PageDown keys added, Home remapped from ~ to "Home"

### DIFF
--- a/fff
+++ b/fff
@@ -60,6 +60,7 @@ get_term_size() {
 
     # Max list items that fit in the scroll area.
     ((max_items=LINES-3))
+    ((scroll_page=max_items-5))
 }
 
 get_ls_colors() {
@@ -550,6 +551,40 @@ key() {
             fi
         ;;
 
+        # Page up
+        "${FFF_KEY_PAGE_DOWN1:=6}")
+            for ((ii=0; ii<scroll_page; ii++)) do
+                ((scroll >= list_total)) && break
+                ((scroll++))
+                ((y < max_items )) && ((y++))
+
+                print_line "$((scroll-1))"
+                printf '\n'
+                print_line "$scroll"
+                status_line
+            done
+        ;;
+
+        # Page down
+        "${FFF_KEY_PAGE_UP1:=5}")
+            for ((ii=0; ii<scroll_page; ii++)) do
+                ((scroll <= 0)) && break
+                ((scroll--))
+
+                print_line "$((scroll+1))"
+
+                if ((y < 2)); then
+                    printf '\e[1L'
+                else
+                    printf '\e[A'
+                    ((y--))
+                fi
+
+                print_line "$scroll"
+                status_line
+            done
+        ;;
+
         # Scroll down.
         # 'B' is what bash sees when the down arrow is pressed ('\e[B').
         "${FFF_KEY_SCROLL_DOWN1:=j}"|\
@@ -566,7 +601,7 @@ key() {
         ;;
 
         # Scroll up.
-        # 'A' is what bash sees when the down arrow is pressed ('\e[A').
+        # 'A' is what bash sees when the up arrow is pressed ('\e[A').
         "${FFF_KEY_SCROLL_UP1:=k}"|\
         "${FFF_KEY_SCROLL_UP2:=A}")
             # '\e[1L': Insert a line above the cursor.
@@ -741,7 +776,7 @@ key() {
         ;;
 
         # Go to '$HOME'.
-        "${FFF_KEY_GO_HOME:=~}")
+        "${FFF_KEY_GO_HOME:=1}")
             open ~
         ;;
 

--- a/fff.1
+++ b/fff.1
@@ -143,9 +143,15 @@ export FFF_KEY_SHELL="s"
 export FFF_KEY_SCROLL_DOWN1="j"
 export FFF_KEY_SCROLL_DOWN2="B" # Down Arrow
 
+# Page down.
+export FFF_KEY_PAGE_DOWN1="6" # PgDn key
+
 # Scroll up.
 export FFF_KEY_SCROLL_UP1="k"
 export FFF_KEY_SCROLL_UP2="A" # Up Arrow
+
+# Page up
+export FFF_KEY_PAGE_UP1="5" # PgUp key
 
 # Go to top and bottom.
 export FFF_KEY_TO_TOP="g"
@@ -153,7 +159,7 @@ export FFF_KEY_TO_BOTTOM="G"
 
 # Go to dirs.
 export FFF_KEY_GO_DIR=":"
-export FFF_KEY_GO_HOME="~"
+export FFF_KEY_GO_HOME="1" # Home key
 export FFF_KEY_GO_TRASH="t"
 
 ### File operations.


### PR DESCRIPTION
Now PgUp/PgDown keys can be used. I have to remap Home from ~ to Home key because the PgUp/PgDown sequences are ^[[5~ and ^[[6~ and these sequnces trigger ~ binding.