### PR TITLE
general: Added options to configure file strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ export FFF_FAV9=
 # w3m-img offsets.
 export FFF_W3M_XOFFSET=0
 export FFF_W3M_YOFFSET=0
+
+# File format.
+# Customize the item string.
+# Format ('%f' is the current file): "str%fstr"
+# Example (Add a tab before files): FFF_FILE_FORMAT="\t%f"
+export FFF_FILE_FORMAT="%f"
+
+# Mark format.
+# Customize the marked item string.
+# Format ('%f' is the current file): "str%fstr"
+# Example (Add a ' >' before files): FFF_MARK_FORMAT="> %f"
+export FFF_MARK_FORMAT=" %f*"
 ```
 
 ## Customizing the keybindings.

--- a/fff
+++ b/fff
@@ -64,6 +64,25 @@ clear_screen() {
            "$((LINES-2))" "${TMUX:+\e[2J}" "$max_items"
 }
 
+setup_options() {
+    # Some options require some setup.
+    # This function is called once on open to parse
+    # select options so the operation isn't repeated
+    # multiple times in the code.
+
+    # Format for normal files.
+    [[ $FFF_FILE_FORMAT == *%f* ]] && {
+        file_pre="${FFF_FILE_FORMAT/'%f'*}"
+        file_post="${FFF_FILE_FORMAT/*'%f'}"
+    }
+
+    # Format for marked files.
+    [[ $FFF_MARK_FORMAT == *%f* ]] && {
+        mark_pre="${FFF_MARK_FORMAT/'%f'*}"
+        mark_post="${FFF_MARK_FORMAT/*'%f'}"
+    }
+}
+
 get_term_size() {
     # Get terminal size ('stty' is POSIX and always available).
     # This can't be done reliably across all bash versions in pure bash.
@@ -269,15 +288,17 @@ print_line() {
 
     # If the list item is marked for operation.
     [[ ${marked_files[$1]} == "${list[$1]:-null}" ]] && {
-        format+="\\e[3${FFF_COL3:-1}m "
-        suffix+='*'
+        format+="\\e[3${FFF_COL3:-1}m${mark_pre:= }"
+        suffix+="${mark_post:=*}"
     }
 
     # Escape the directory string.
     # Remove all non-printable characters.
     file_name="${file_name//[^[:print:]]/^[}"
 
-    printf '\r%b%s\e[m\r' "$format" "${file_name}${suffix}"
+    printf '\r%b%s\e[m\r' \
+        "${file_pre}${format}" \
+        "${file_name}${suffix}${file_post}"
 }
 
 draw_dir() {
@@ -1010,6 +1031,7 @@ main() {
 
     get_os
     get_term_size
+    setup_options
     setup_terminal
 
     # Set some bash options.

--- a/fff.1
+++ b/fff.1
@@ -123,6 +123,18 @@ export FFF_FAV9=
 # w3m-img offsets.
 export FFF_W3M_XOFFSET=0
 export FFF_W3M_YOFFSET=0
+
+# File format.
+# Customize the item string.
+# Format ('%f' is the current file): "str%fstr"
+# Example (Add a tab before files): FFF_FILE_FORMAT="\t%f"
+export FFF_FILE_FORMAT="%f"
+
+# Mark format.
+# Customize the marked item string.
+# Format ('%f' is the current file): "str%fstr"
+# Example (Add a ' >' before files): FFF_MARK_FORMAT="> %f"
+export FFF_MARK_FORMAT=" %f*"
 .
 .fi
 .


### PR DESCRIPTION
Format:

```sh
# File format.
# Customize the item string.
# Format ('%f' is the current file): "str%fstr"
# Example (Add a tab before files): FFF_FILE_FORMAT="\t%f"
export FFF_FILE_FORMAT="%f"

# Mark format.
# Customize the marked item string.
# Format ('%f' is the current file): "str%fstr"
# Example (Add a ' >' before files): FFF_MARK_FORMAT="> %f"
export FFF_MARK_FORMAT=" %f*"
```

Closes #85 