### PR TITLE
FFF_ERROR_ON_SIGINT option

### DIFF
--- a/fff
+++ b/fff
@@ -1040,9 +1040,14 @@ main() {
     # Trap the exit signal (we need to reset the terminal to a useable state.)
     trap 'reset_terminal' EXIT
 
-    # Trap 'Ctrl+c' and exit by mimicking the 'q' keypress.
-    # This allow us to run the same plumbing on exit for both.
-    trap 'key q' INT
+    # If FFF_ERROR_ON_SIGINT is 1, trap 'Ctrl+c' and exit by
+    # mimicking the 'q' keypress. This allow us to run the same
+    # plumbing on exit for both.
+    if [ "$FFF_ERROR_ON_SIGINT" -eq 1 ]; then
+        trap 'key q' INT
+    else
+        trap 'reset_terminal && exit 1' INT
+    fi
 
     # Trap the window resize signal (handle window resize events).
     trap 'get_term_size; redraw' WINCH

--- a/fff.1
+++ b/fff.1
@@ -97,6 +97,10 @@ export FFF_OPENER="xdg\-open"
 #          If not using XDG, '${HOME}/.cache/fff/fff.d' is used.
 export FFF_CD_FILE=~/.fff_d
 
+# Exit with error without writing to FFF_CD_FILE on SIGINT (C-c)
+# Default: (disabled)
+export FFF_ERROR_ON_SIGINT=1
+
 # Trash Directory
 # Default: '${XDG_DATA_HOME}/fff/trash'
 #          If not using XDG, '${XDG_DATA_HOME}/fff/trash' is used.


### PR DESCRIPTION
If set to 1, then SIGINT makes fff exit with error 130 without
writing to $FFF_CD_FILE.