### PR TITLE
Added key for refresh current dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ export FFF_KEY_TO_BOTTOM="G"
 export FFF_KEY_GO_DIR=":"
 export FFF_KEY_GO_HOME="~"
 export FFF_KEY_GO_TRASH="t"
-export FFF_KET_REFRESH="e"
+export FFF_KEY_REFRESH="e"
 
 ### File operations.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ G: go to bottom
 /: search
 t: go to trash
 ~: go to home
+e: refresh current dir
 !: open shell in current dir
 
 x: view file/dir attributes
@@ -279,6 +280,7 @@ export FFF_KEY_TO_BOTTOM="G"
 export FFF_KEY_GO_DIR=":"
 export FFF_KEY_GO_HOME="~"
 export FFF_KEY_GO_TRASH="t"
+export FFF_KET_REFRESH="e"
 
 ### File operations.
 

--- a/fff
+++ b/fff
@@ -1012,6 +1012,11 @@ key() {
             open "$OLDPWD"
         ;;
 
+        # Refresh current dir.
+        "${FFF_KEY_REFRESH:=e}")
+            open "$PWD"
+        ;;
+
         # Directory favourites.
         [1-9])
             favourite="FFF_FAV${1}"


### PR DESCRIPTION
Sometimes it's really annoying I can't reload current dir if some changes in filesystem made outside of running fff. So I've made a change adding a hotkey to refresh current dir. Hotkey "e" inspired by ":e" and ":edit" in Vim, allowing to load changes made outside opened buffer. 