### PR TITLE
add ? to display keyboard shortcuts

### DIFF
--- a/fff
+++ b/fff
@@ -1047,6 +1047,13 @@ key() {
                 open "$favourite"
         ;;
 
+        "?")
+            clear_screen
+            man fff | grep -A 54 "^Usage" | column
+            read -ern 1
+            open "$PWD"
+        ;;
+?
         # Quit and store current directory in a file for CD on exit.
         # Don't allow user to redefine 'q' so a bad keybinding doesn't
         # remove the option to quit.


### PR DESCRIPTION
### ?: display keyboard shortcuts
```
sage                                                                  right: go to child dir
       j: scroll down                                                  f: new file
       k: scroll up                                                    n: new dir
       h: go to parent dir                                             r: rename
       l: go to child dir                                              X: toggle executable
       enter: go to child dir                                          y: mark copy
       backspace: go to parent dir                                     m: mark move
       -: Go to previous dir.                                          d: mark trash (~/.local/share/fff/trash/)
       g: go to top                                                    s: mark symbolic link
       G: go to bottom                                                 b: mark bulk rename
       :: go to a directory by typing.                                 Y: mark all for copy
       /: search                                                       M: mark all for move
       t: go to trash                                                  D: mark all for trash (~/.local/share/fff/trash/)
       ~: go to home                                                   S: mark all for symbolic link
       e: refresh current dir                                          B: mark all for bulk rename
       !: open shell in current dir                                    p: paste/move/delete/bulk_rename
       x: view file/dir attributes                                     c: clear file selections
       i: display image with w3m-img                                   [1-9]: favourites/bookmarks (see customization)
       down:  scroll down                                              q: exit with 'cd' (if enabled).
       up:    scroll up                                                Ctrl+C: exit without 'cd'.
       left:  go to parent dir

```