### PR TITLE
Additional key bindings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ export EDITOR="vim"
 # File Opener
 export FFF_OPENER="xdg-open"
 
+# File Attributes Command
+export FFF_STAT_CMD="stat"
+
 # Enable or disable CD on exit.
 # Default: '1'
 export FFF_CD_ON_EXIT=1

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ export FFF_CD_FILE=~/.fff_d
 
 # Trash Directory
 # Default: '${XDG_DATA_HOME}/fff/trash'
-#          If not using XDG, '${XDG_DATA_HOME}/fff/trash' is used.
+#          If not using XDG, '${HOME}/.local/share/fff/trash' is used.
 export FFF_TRASH=~/.local/share/fff/trash
 
 # Trash Command

--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ Ctrl+C: exit without 'cd'.
 ## Customization
 
 ```sh
+# Show/Hide hidden files on open.
+# (Off by default)
+export FFF_HIDDEN=1
+
 # Use LS_COLORS to color fff.
 # (On by default if available)
 # (Ignores FFF_COL1)
 export FFF_LS_COLORS=1
-
-# Show/Hide hidden files on open.
-# (On by default)
-export FFF_HIDDEN=0
 
 # Directory color [0-9]
 export FFF_COL1=2
@@ -208,8 +208,8 @@ export FFF_OPENER="xdg-open"
 export FFF_STAT_CMD="stat"
 
 # Enable or disable CD on exit.
-# Default: '1'
-export FFF_CD_ON_EXIT=1
+# (On by default)
+export FFF_CD_ON_EXIT=0
 
 # CD on exit helper file
 # Default: '${XDG_CACHE_HOME}/fff/fff.d'

--- a/fff
+++ b/fff
@@ -984,7 +984,7 @@ key() {
             [[ -e "${list[scroll]}" ]] && {
                 clear_screen
                 status_line "${list[scroll]}"
-                stat "${list[scroll]}"
+                "${FFF_STAT_CMD:-stat}" "${list[scroll]}"
                 read -ern 1
                 redraw
             }

--- a/fff
+++ b/fff
@@ -738,15 +738,12 @@ cmd_line() {
 key() {
     # Handle special key presses.
     [[ $1 == $'\e' ]] && {
-        #       \e  A           | Alt+[char]
-        #       \e  [  A        | Arrow Keys
-        #       \e  O  A        | Arrow Keys
-        #       \e  [  6  ~     | PG(UP/DWN) , Home , End
-        #       \e  [  2  0  ~  | Function keys
-        #       \e  [  1  ;  5~ | Ctrl + PG(UP/DWN) , Home , End
-        #       \e  [  1  ;  5C | Ctrl + Arrow_keys
-        #       --  -  -  -  --
-        # Part   1  2  3  4   5
+        #       \e  A        | Alt+[char]
+        #       \e  [  A     | Arrow Keys
+        #       \e  O  A     | Arrow Keys
+        #       \e  [  6  ~  | PG(UP/DWN) , Home , End
+        #       --  -  -  - 
+        # Part   1  2  3  4 
         # 
         # Part-1 is $1
 
@@ -766,18 +763,6 @@ key() {
                 # Read Part-4
                 read "${read_flags[@]}" -srn 1
                 special_key+=${REPLY}
-                
-                [[ ${REPLY} == [[:digit:]] ]] && {
-                    # Read one char from Part-5 
-                    read "${read_flags[@]}" -srn 1 _
-                    special_key+="~"
-                }
-
-                [[ ${REPLY} == ";" ]] && {
-                    # Read the whole of Part-5
-                    read "${read_flags[@]}" -srn 2
-                    special_key+=${REPLY}
-                }
             }
         }
     }
@@ -858,7 +843,7 @@ key() {
         ;;
 
         # Go to top.
-        ${FFF_KEY_TO_TOP:=g})
+        ${FFF_KEY_TO_TOP:=$'\e[1~'})
             ((scroll != 0)) && {
                 scroll=0
                 redraw
@@ -866,7 +851,7 @@ key() {
         ;;
 
         # Go to bottom.
-        ${FFF_KEY_TO_BOTTOM:=G})
+        ${FFF_KEY_TO_BOTTOM:=$'\e[4~'})
             ((scroll != list_total)) && {
                 ((scroll=list_total))
                 redraw

--- a/fff
+++ b/fff
@@ -738,13 +738,48 @@ cmd_line() {
 key() {
     # Handle special key presses.
     [[ $1 == $'\e' ]] && {
-        read "${read_flags[@]}" -rsn 2
+        #       \e  A           | Alt+[char]
+        #       \e  [  A        | Arrow Keys
+        #       \e  O  A        | Arrow Keys
+        #       \e  [  6  ~     | PG(UP/DWN) , Home , End
+        #       \e  [  2  0  ~  | Function keys
+        #       \e  [  1  ;  5~ | Ctrl + PG(UP/DWN) , Home , End
+        #       \e  [  1  ;  5C | Ctrl + Arrow_keys
+        #       --  -  -  -  --
+        # Part   1  2  3  4   5
+        # 
+        # Part-1 is $1
 
-        # Handle a normal escape key press.
-        [[ ${1}${REPLY} == $'\e\e['* ]] &&
-            read "${read_flags[@]}" -rsn 1 _
+        local special_key
+        special_key+=${1}
 
-        local special_key=${1}${REPLY}
+        # Read Part-2
+        read "${read_flags[@]}" -srn 1
+        special_key+=${REPLY}
+
+        [[ $REPLY == '[' || $REPLY == 'O' ]] && {
+            # Read Part-3
+            read "${read_flags[@]}" -srn 1
+            special_key+=${REPLY}
+
+            [[ ${REPLY} == [0-9] ]] && {
+                # Read Part-4
+                read "${read_flags[@]}" -srn 1
+                special_key+=${REPLY}
+                
+                [[ ${REPLY} == [[:digit:]] ]] && {
+                    # Read one char from Part-5 
+                    read "${read_flags[@]}" -srn 1 _
+                    special_key+="~"
+                }
+
+                [[ ${REPLY} == ";" ]] && {
+                    # Read the whole of Part-5
+                    read "${read_flags[@]}" -srn 2
+                    special_key+=${REPLY}
+                }
+            }
+        }
     }
 
     case ${special_key:-$1} in

--- a/fff.1
+++ b/fff.1
@@ -102,6 +102,9 @@ export EDITOR="vim"
 # File Opener
 export FFF_OPENER="xdg\-open"
 
+# File Attributes Command
+export FFF_STAT_CMD="stat"
+
 # Enable or disable CD on exit.
 # Default: '1'
 export FFF_CD_ON_EXIT=1


### PR DESCRIPTION
The below keys can now be used in `fff`
```
PG(UP/DWN)  :  \e[5~ or \e[6~  
HOME        :  \e[1~ 
END         :  \e[4~ 
F1-4        :  \eOP  ( Q , R , S )
F5-12       :  \e15~  (17~ , 18~ , 19~ , 20~ , 21~ , 23~ , 24~ )
Ctrl+Arrow  :  \e1;5A  (;5B , ;5C , ;5D )
```
Other keys might be supported. I haven't checked.