### PR TITLE
Minor update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ Ctrl+C: exit without 'cd'.
 ## Customization
 
 ```sh
+# Show/Hide hidden files on open.
+# (Off by default)
+export FFF_HIDDEN=1
+
 # Use LS_COLORS to color fff.
 # (On by default if available)
 # (Ignores FFF_COL1)
 export FFF_LS_COLORS=1
-
-# Show/Hide hidden files on open.
-# (On by default)
-export FFF_HIDDEN=0
 
 # Directory color [0-9]
 export FFF_COL1=2
@@ -208,8 +208,8 @@ export FFF_OPENER="xdg-open"
 export FFF_STAT_CMD="stat"
 
 # Enable or disable CD on exit.
-# Default: '1'
-export FFF_CD_ON_EXIT=1
+# (On by default)
+export FFF_CD_ON_EXIT=0
 
 # CD on exit helper file
 # Default: '${XDG_CACHE_HOME}/fff/fff.d'


### PR DESCRIPTION
Showing hidden files is turned off by default, so I fixed the text at the FFF_HIDDEN section to say it so.
I also changed the suggested command to reflect a different behavior than the default, thus letting the user customize the experience.

While I was at it, I formatted and edited the FFF_CD_ON_EXIT section for similar reasons.

Finally, I swapped FFF_LS_COLORS and FFF_HIDDEN sections so as to let the color-related FFF_LS_COLORS be next to the other color-related settings.
(also, FFF_HIDDEN is a more important setting to be found than FFF_LS_COLORS, if you ask me)