### PR TITLE
Fix marked_files out of bounds

### DIFF
--- a/fff
+++ b/fff
@@ -196,12 +196,12 @@ read_dir() {
     for item in "$PWD"/*; do
         if [[ -d $item ]]; then
             dirs+=("$item")
-            ((item_index++))
 
             # Find the position of the child directory in the
             # parent directory list.
             [[ $item == "$OLDPWD" ]] &&
                 ((previous_index=item_index))
+            ((item_index++))
         else
             files+=("$item")
         fi
@@ -313,7 +313,7 @@ draw_dir() {
     # When going up the directory tree, place the cursor on the position
     # of the previous directory.
     ((find_previous == 1)) && {
-        ((scroll_start=previous_index-1))
+        ((scroll_start=previous_index))
         ((scroll=scroll_start))
 
         # Clear the directory history. We're here now.


### PR DESCRIPTION
If at start the parent directory contains only hidden files, and hidden
option is turned off. And we move to the parent directory we will get:
fff: line 293: marked_files: bad array subscript

Found out this was due to $previous_index being 0 and we do -1 off of it.
So $scroll and $scroll_start would end up being -1 also.
Quick fix, store $previous_index starting from 0 rather than 1 just like
$scroll variable. And don't minus 1 from it.