### PR TITLE
Enable cd on exit by sourcing the main script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ A simple file manager written in `bash`.
 **NOTE:** `fff` can be uninstalled easily using `make uninstall`. This removes all of files from your system.
 
 ### CD on Exit
+#### Bash
+```sh
+# Add this to your .bashrc or equivalent.
+. fff
+```
 #### Bash and Zsh
 ```sh
 # Add this to your .bashrc, .zshrc or equivalent.

--- a/fff
+++ b/fff
@@ -2,6 +2,16 @@
 #
 # fff - fucking fast file-manager.
 
+# Enable cd on exit by sourcing fff
+if (return 0 2>/dev/null); then
+    function fff {
+        command fff "$@"
+        [[ ${FFF_CD_ON_EXIT:-1} == 1 ]] &&
+            cd "$(cat "${XDG_CACHE_HOME:-${HOME}/.cache}/fff/.fff_d")"
+    }
+    return
+fi
+
 get_os() {
     # Figure out the current operating system to set some specific variables.
     # '$OSTYPE' typically stores the name of the OS kernel.


### PR DESCRIPTION
This patch makes it so that Bash users need only run this to enable the change directory feature:
```sh
. fff
```
It still respects the environment, so this invocation won't cd:
```sh
FFF_CD_ON_EXIT=0 fff
```
The default behaviour is easily restored:
```sh
unset fff
```