### PR TITLE
Always act as file picker when instructed

### DIFF
--- a/fff
+++ b/fff
@@ -592,6 +592,14 @@ open() {
         redraw full
 
     elif [[ -f $1 ]]; then
+        # If 'fff' was opened as a file picker, save the opened
+        # file in a file called 'opened_file'.
+        ((file_picker == 1)) && {
+            printf '%s\n' "$1" > \
+                "${XDG_CACHE_HOME:=${HOME}/.cache}/fff/opened_file"
+            exit
+        }
+
         # Figure out what kind of file we're working with.
         get_mime_type "$1"
 
@@ -599,14 +607,6 @@ open() {
         # Everything else goes through 'xdg-open'/'open'.
         case "$mime_type" in
             text/*|*x-empty*|*json*)
-                # If 'fff' was opened as a file picker, save the opened
-                # file in a file called 'opened_file'.
-                ((file_picker == 1)) && {
-                    printf '%s\n' "$1" > \
-                        "${XDG_CACHE_HOME:=${HOME}/.cache}/fff/opened_file"
-                    exit
-                }
-
                 clear_screen
                 reset_terminal
                 "${VISUAL:-${EDITOR:-vi}}" "$1"


### PR DESCRIPTION
Should not be conditional on MIME type, otherwise many types, e.g.: `application/javascript`, can never be selected and will instead open in a separate program or instance.